### PR TITLE
bugfix: An open box of donuts has a sprite

### DIFF
--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -30,6 +30,7 @@
 	icon = 'icons/obj/food.dmi'
 	icon_state = "donutbox"
 	name = "donut box"
+	open_icon = "donutbox"
 	can_hold = list(/obj/item/reagent_containers/food/snacks/donut)
 	foldable = /obj/item/stack/material/cardboard
 


### PR DESCRIPTION
## Чё получилось

В общем существовала проблема что у открытой коробки пончиков отсутствовал спрайт и игра ставила ему чёрно фиолетовый квадратик, теперь не ставит )
![image](https://github.com/MysticalFaceLesS/Foundation-19/assets/96659221/00359f3f-a651-4401-86cd-051516165ccd)

